### PR TITLE
Vagrant CloudStack post-processor

### DIFF
--- a/plugin/post-processor-vagrant/main.go
+++ b/plugin/post-processor-vagrant/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/klarna/packer-cloudstack/post-processor/vagrant"
+	"github.com/mitchellh/packer/packer/plugin"
+)
+
+func main() {
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+	server.RegisterPostProcessor(new(vagrant.PostProcessor))
+	server.Serve()
+}

--- a/plugin/post-processor-vagrant/main_test.go
+++ b/plugin/post-processor-vagrant/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/post-processor/vagrant/cloudstack.go
+++ b/post-processor/vagrant/cloudstack.go
@@ -1,0 +1,71 @@
+package vagrant
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/url"
+	"text/template"
+
+	"github.com/mitchellh/packer/packer"
+)
+
+type CloudStackProvider struct{}
+
+func (p *CloudStackProvider) KeepInputArtifact() bool {
+	return true
+}
+
+func (p *CloudStackProvider) Process(ui packer.Ui, artifact packer.Artifact, dir string) (vagrantfile string, metadata map[string]interface{}, err error) {
+	// Create the metadata
+	metadata = map[string]interface{}{"provider": "cloudstack"}
+
+	// Build up the template data to build our Vagrantfile
+	tplData := &cloudStackVagrantfileTemplate{}
+
+	url, err := url.Parse(artifact.Id())
+	if err != nil {
+		err = fmt.Errorf("Poorly formatted artifact ID: %s", artifact.Id())
+		return
+	}
+	host, port, err := net.SplitHostPort(url.Host)
+	if err != nil {
+		err = fmt.Errorf("Network address has an invalid form: %s", artifact.Id())
+		return
+	}
+	tplData.Host = host
+	tplData.Port = port
+	tplData.Path = url.Path
+	tplData.Scheme = url.Scheme
+	values := url.Query()
+	tplData.TemplateId = values.Get("templateid")
+
+	// Build up the Vagrantfile
+	var contents bytes.Buffer
+	tpl := template.Must(template.New("vf").Parse(defaultCloudStackVagrantfile))
+	err = tpl.Execute(&contents, tplData)
+	vagrantfile = contents.String()
+
+	return
+}
+
+type cloudStackVagrantfileTemplate struct {
+	Host       string
+	Path       string
+	Port       string
+	Scheme     string "http"
+	TemplateId string
+}
+
+var defaultCloudStackVagrantfile = `
+Vagrant.configure("2") do |config|
+  config.vm.provider "cloudstack" do |cloudstack|
+    cloudstack.host = "{{ .Host }}"
+    cloudstack.path = "{{ .Path }}"
+    cloudstack.port = "{{ .Port }}"
+    cloudstack.scheme = "{{ .Scheme }}"
+
+    cloudstack.template_id = "{{ .TemplateId }}"
+  end
+end
+`

--- a/post-processor/vagrant/cloudstack_test.go
+++ b/post-processor/vagrant/cloudstack_test.go
@@ -1,0 +1,17 @@
+package vagrant
+
+import (
+	"testing"
+)
+
+func TestCloudStackProvider_impl(t *testing.T) {
+	var _ Provider = new(CloudStackProvider)
+}
+
+func TestCloudStackProvider_KeepInputArtifact(t *testing.T) {
+	p := new(CloudStackProvider)
+
+	if !p.KeepInputArtifact() {
+		t.Fatal("should keep input artifact")
+	}
+}

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -1,0 +1,18 @@
+package vagrant
+
+import (
+	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/post-processor/vagrant"
+)
+
+type PostProcessor struct {
+	vagrant.PostProcessor
+}
+
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+	if artifact.BuilderId() != "mindjiver.cloudstack" {
+		return p.PostProcessor.PostProcess(ui, artifact)
+	}
+
+	return p.PostProcessor.PostProcessProvider("cloudstack", new(CloudStackProvider), ui, artifact)
+}

--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -1,0 +1,1 @@
+package vagrant


### PR DESCRIPTION
Add support for CloudStack Vagrant post-processor targeting the Vagrant
Cloudstack Provider. The Vagrantfile embedded inside the box contains
the template id and the CloudStack API URL as the built template is only
valid for that particular CloudStack instance.
